### PR TITLE
api.metadata: remove data-key

### DIFF
--- a/landsatxplore/api.py
+++ b/landsatxplore/api.py
@@ -157,4 +157,4 @@ class API(object):
             id_list = self.lookup(dataset, id_list, inverse=True)
         params = {'datasetName': dataset, 'entityIds': id_list}
         response = self.request('metadata', **params)
-        return response['data']
+        return response


### PR DESCRIPTION
This mini-PR fixes the bug that `API.metadata()` fails because it tries to get `response['data']`, but `response` is already a list, as it was extracted before in `API.request()`.