### PR TITLE
Add timeout parameter to landsatxplore download

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ Usage: landsatxplore download [OPTIONS] [SCENES]...
   Download one or several Landsat scenes.
 
 Options:
-  -u, --username TEXT  EarthExplorer username.
-  -p, --password TEXT  EarthExplorer password.
-  -o, --output PATH    Output directory (default to current).
-  --help               Show this message and exit.
+  -u, --username TEXT    EarthExplorer username.
+  -p, --password TEXT    EarthExplorer password.
+  -o, --output PATH      Output directory (default to current).
+  -t, --timeout INTEGER  Download timeout in seconds (default 60s).
+  --help                 Show this message and exit.
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Options:
   -u, --username TEXT    EarthExplorer username.
   -p, --password TEXT    EarthExplorer password.
   -o, --output PATH      Output directory (default to current).
-  -t, --timeout INTEGER  Download timeout in seconds (default 60s).
+  -t, --timeout INTEGER  Download timeout in seconds (default 300s).
   --help                 Show this message and exit.
 ```
 

--- a/README.rst
+++ b/README.rst
@@ -73,10 +73,12 @@ Downloading
       Download one or several Landsat scenes.
 
     Options:
-      -u, --username TEXT  EarthExplorer username.
-      -p, --password TEXT  EarthExplorer password.
-      -o, --output PATH    Output directory.
-      --help               Show this message and exit.
+      -u, --username TEXT    EarthExplorer username.
+      -p, --password TEXT    EarthExplorer password.
+      -o, --output PATH      Output directory (default to current).
+      -t, --timeout INTEGER  Download timeout in seconds (default 60s).
+      --help                 Show this message and exit.
+
 
 API
 ---

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ Downloading
       -u, --username TEXT    EarthExplorer username.
       -p, --password TEXT    EarthExplorer password.
       -o, --output PATH      Output directory (default to current).
-      -t, --timeout INTEGER  Download timeout in seconds (default 60s).
+      -t, --timeout INTEGER  Download timeout in seconds (default 300s).
       --help                 Show this message and exit.
 
 

--- a/landsatxplore/cli.py
+++ b/landsatxplore/cli.py
@@ -90,15 +90,17 @@ def search(username, password, dataset, location, bbox, clouds, start, end, outp
               envvar='LANDSATXPLORE_PASSWORD')
 @click.option('--output', '-o', type=click.Path(exists=True, dir_okay=True),
               default='.', help='Output directory.')
+@click.option('--timeout', '-t', type=click.INT, default=60,
+              help='Download timeout in seconds.')
 @click.argument('scenes', type=click.STRING, nargs=-1)
-def download(username, password, output, scenes):
+def download(username, password, output, timeout, scenes):
     """Download one or several Landsat scenes."""
     ee = EarthExplorer(username, password)
     output_dir = os.path.abspath(output)
     for scene in scenes:
         if not ee.logged_in():
             ee = EarthExplorer(username, password)
-        ee.download(scene, output_dir)
+        ee.download(scene, output_dir, timeout)
     ee.logout()
 
 

--- a/landsatxplore/cli.py
+++ b/landsatxplore/cli.py
@@ -90,7 +90,7 @@ def search(username, password, dataset, location, bbox, clouds, start, end, outp
               envvar='LANDSATXPLORE_PASSWORD')
 @click.option('--output', '-o', type=click.Path(exists=True, dir_okay=True),
               default='.', help='Output directory.')
-@click.option('--timeout', '-t', type=click.INT, default=60,
+@click.option('--timeout', '-t', type=click.INT, default=300,
               help='Download timeout in seconds.')
 @click.argument('scenes', type=click.STRING, nargs=-1)
 def download(username, password, output, timeout, scenes):

--- a/landsatxplore/earthexplorer.py
+++ b/landsatxplore/earthexplorer.py
@@ -89,7 +89,7 @@ class EarthExplorer(object):
                 'Connection timeout after {} seconds.'.format(timeout))
         return local_filename
 
-    def download(self, scene_id, output_dir, timeout=60):
+    def download(self, scene_id, output_dir, timeout=300):
         """Download a Landsat scene given its identifier and an output
         directory.
         """

--- a/landsatxplore/earthexplorer.py
+++ b/landsatxplore/earthexplorer.py
@@ -2,7 +2,6 @@
 
 import os
 import re
-import time
 import shutil
 
 import requests


### PR DESCRIPTION
This PR adds a `timeout` parameter that defines how long a `landsatxplore download` request should wait for a response before aborting.
In some cases, the Earth Explorer takes a lot of time to respond - for these cases the `timeout` parameter ensures that a) the process is not aborted before a certain amount of time has passed and b) the amount of time to wait for a response is finite.

A conservative value of 300 seconds (= 5 minutes) is set as default value in order to not break any existing processing chains where long EE response times may occur.
