### PR TITLE
Add download resume/skip on partly completed files

### DIFF
--- a/landsatxplore/cli.py
+++ b/landsatxplore/cli.py
@@ -151,8 +151,9 @@ def search(
     "--timeout", "-t", type=click.INT, default=300, help="Download timeout in seconds."
 )
 @click.option("--skip", is_flag=True, default=False)
+@click.option("--overwrite", is_flag=True, default=False)
 @click.argument("scenes", type=click.STRING, nargs=-1)
-def download(username, password, dataset, output, timeout, skip, scenes):
+def download(username, password, dataset, output, timeout, skip, overwrite, scenes):
     """Download one or several scenes."""
     ee = EarthExplorer(username, password)
     output_dir = os.path.abspath(output)
@@ -162,7 +163,12 @@ def download(username, password, dataset, output, timeout, skip, scenes):
         if not ee.logged_in():
             ee = EarthExplorer(username, password)
         fname = ee.download(
-            scene, output_dir, dataset=dataset, timeout=timeout, skip=skip
+            scene,
+            output_dir,
+            dataset=dataset,
+            timeout=timeout,
+            skip=skip,
+            overwrite=overwrite,
         )
         if skip:
             click.echo(fname)


### PR DESCRIPTION
This pr adds support for download resume if a requested file is partly downloaded or skip the download if the server file size is the same as the local file size (except if --overwrite flag is passed).

Notes:

- The server seems to support `Range` Header in every file I tested, even though it reports `Accept-Range: None` if you don't specify the `Range` header. (But if `Range` header is specified eg. `Range: bytes=500-` in the request, then the response is `Accept-Range: Bytes`).
- 2 get requests are sent to the server. The first one to get the filename and the second one to download the file. Maybe the first one could be replaced with the `metadata["display_id"]` value + the right extension (tar.gz in all cases?). But I don't know if file names always follow that convention.
- As far as I know, not any kind of file checksum is provided on the M2M API, so download is being skipped by checking the file size which isn't a perfect solution, but i think it works fine.

Resolves #39 