### PR TITLE
Quick fix to prevent errors when downloading Landsat 8 Collection 2. …

### DIFF
--- a/landsatxplore/earthexplorer.py
+++ b/landsatxplore/earthexplorer.py
@@ -32,6 +32,19 @@ DATA_PRODUCTS = {
     "sentinel_2a": "5e83a42c6eba8084",
 }
 
+# Quick fix to use fallback paths for Landsat 8 errors (suggested at https://github.com/yannforget/landsatxplore/issues/45)
+DATA_PRODUCTS_II = {
+    "landsat_tm_c1": "5e83d08fd9932768",
+    "landsat_etm_c1": "5e83a507d6aaa3db",
+    "landsat_8_c1": "5e83d0b84df8d8c2",
+    "landsat_tm_c2_l1": "5e83d0a0f94d7d8d",
+    "landsat_etm_c2_l1": "5e83d0d08fec8a66",
+    "landsat_ot_c2_l1": "5e81f14f92acf9ef",
+    "landsat_tm_c2_l2": "5e83d11933473426",
+    "landsat_etm_c2_l2": "5e83d12aed0efa58",
+    "landsat_ot_c2_l2": "5e83d14fec7cae84",
+    "sentinel_2a": "5e83a42c6eba8084",
+}
 
 def _get_tokens(body):
     """Get `csrf_token` and `__ncforminfo`."""
@@ -144,8 +157,16 @@ class EarthExplorer(object):
             entity_id = self.api.get_entity_id(identifier, dataset)
         else:
             entity_id = identifier
-        url = EE_DOWNLOAD_URL.format(
-            data_product_id=DATA_PRODUCTS[dataset], entity_id=entity_id
-        )
-        filename = self._download(url, output_dir, timeout=timeout, skip=skip)
+        
+        # Quick fix to use fallback paths for Landsat 8 errors (suggested at https://github.com/yannforget/landsatxplore/issues/45)
+        try:
+            url = EE_DOWNLOAD_URL.format(
+                data_product_id=DATA_PRODUCTS[dataset], entity_id=entity_id
+                )
+            filename = self._download(url, output_dir, timeout=timeout, skip=skip)
+        except:
+            url = EE_DOWNLOAD_URL.format(
+                data_product_id=DATA_PRODUCTS_II[dataset], entity_id=entity_id
+                )
+            filename = self._download(url, output_dir, timeout=timeout, skip=skip)
         return filename


### PR DESCRIPTION
…See  #42 and #45 

I tested this fix on Debian and it allowed me to download a Landsat 8 C2 scene that had previously thrown an error:
```landsatxplore download --output . LC08_L2SP_038023_20180607_20200831_02_T1```

I would appreciate if someone could test once more before accepting the change, as this is my first ever pull request to someone else's open-source project!