### PR TITLE
Cumulative fixes and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Description
 
-This is a working fork of the **landsatxplore** Python package, which provides an interface to the [EarthExplorer](http://earthexplorer.usgs.gov/) portal to search and download [Landsat Collections](https://landsat.usgs.gov/landsat-collections) scenes through a command-line interface or a Python API. With respect to the original (and now unfortunately abandoned) repo, I removed the decomissioned datasets and fixed some of the issues that kept it from working.
+This is a working fork of the **landsatxplore** Python package, which provides an interface to the [EarthExplorer](http://earthexplorer.usgs.gov/) portal to search and download [Landsat Collections](https://landsat.usgs.gov/landsat-collections) scenes through a command-line interface or a Python API. With respect to the original (and now unfortunately abandoned) repo, I removed the [decomissioned datasets](https://www.usgs.gov/landsat-missions/news/landsat-collection-1-datasets-be-removed-end-2022) and fixed some of the issues that kept it from working.
 These issues were mostly related to outdated dataset ids, to resolve which "permanently" would require restricting the userbase of this Python module to Earth Explorer users with API access. Rather than doing this, I updated the code as suggested by some users in the issues of the old repo, and I will continue doing so for the foreseeable future if necessary.
 
 The following datasets are supported:
@@ -14,6 +14,8 @@ The following datasets are supported:
 | Landsat 7 ETM+ Collection 2 Level 2 | `landsat_etm_c2_l2` |
 | Landsat 8 Collection 2 Level 1 | `landsat_ot_c2_l1` |
 | Landsat 8 Collection 2 Level 2 | `landsat_ot_c2_l2` |
+| Landsat 9 Collection 2 Level 1 | `landsat_ot_c2_l1` |
+| Landsat 9 Collection 2 Level 2 | `landsat_ot_c2_l2` |
 
 # Quick start
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
+[![Build](https://img.shields.io/github/workflow/status/yannforget/landsatxplore/Upload%20Python%20Package?label=build&logo=github)](https://github.com/yannforget/landsatxplore/actions/workflows/python-publish.yml)
+[![Tests](https://img.shields.io/github/workflow/status/yannforget/landsatxplore/Run%20tests?label=tests&logo=github)](https://github.com/yannforget/landsatxplore/actions/workflows/run-tests.yml)
+[![codecov](https://codecov.io/gh/yannforget/landsatxplore/branch/master/graph/badge.svg?token=NwVo09Edur)](https://codecov.io/gh/yannforget/landsatxplore)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1291422.svg)](https://zenodo.org/record/4543601)
+
 # Description
 
 ![CLI Demo](https://raw.githubusercontent.com/yannforget/landsatxplore/master/demo.gif?s=0.5)
 
-This is a working fork of the **landsatxplore** Python package, which provides an interface to the [EarthExplorer](http://earthexplorer.usgs.gov/) portal to search and download [Landsat Collections](https://landsat.usgs.gov/landsat-collections) scenes through a command-line interface or a Python API. With respect to the original (and now unfortunately abandoned) repo, I removed the [decomissioned datasets](https://www.usgs.gov/landsat-missions/news/landsat-collection-1-datasets-be-removed-end-2022) and fixed some of the issues that kept it from working.
-These issues were mostly related to outdated dataset ids, to resolve which "permanently" would require restricting the userbase of this Python module to Earth Explorer users with API access. Rather than doing this, I updated the code as suggested by some users in the issues of the old repo, and I will continue doing so for the foreseeable future if necessary.
+The **landsatxplore** Python package provides an interface to the [EarthExplorer](http://earthexplorer.usgs.gov/) portal to search and download [Landsat Collections](https://landsat.usgs.gov/landsat-collections) scenes through a command-line interface or a Python API.
 
 The following datasets are supported:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Description
 
+![CLI Demo](https://raw.githubusercontent.com/yannforget/landsatxplore/master/demo.gif?s=0.5)
+
 This is a working fork of the **landsatxplore** Python package, which provides an interface to the [EarthExplorer](http://earthexplorer.usgs.gov/) portal to search and download [Landsat Collections](https://landsat.usgs.gov/landsat-collections) scenes through a command-line interface or a Python API. With respect to the original (and now unfortunately abandoned) repo, I removed the [decomissioned datasets](https://www.usgs.gov/landsat-missions/news/landsat-collection-1-datasets-be-removed-end-2022) and fixed some of the issues that kept it from working.
 These issues were mostly related to outdated dataset ids, to resolve which "permanently" would require restricting the userbase of this Python module to Earth Explorer users with API access. Rather than doing this, I updated the code as suggested by some users in the issues of the old repo, and I will continue doing so for the foreseeable future if necessary.
 
@@ -22,14 +24,14 @@ The following datasets are supported:
 Searching for Landsat 5 TM scenes that contains the location (12.53, -1.53) acquired during the year 1995.
 
 ```
-landsatxplore search --dataset LANDSAT_TM_C1 --location 12.53 -1.53 \
+landsatxplore search --dataset landsat_tm_c2_l1 --location 12.53 -1.53 \
     --start 1995-01-01 --end 1995-12-31
 ```
 
 Search for Landsat 7 ETM scenes in Brussels with less than 5% of clouds. Save the returned results in a `.csv` file.
 
 ```
-landsatxplore search --dataset LANDSAT_ETM_C1 \
+landsatxplore search --dataset landsat_tm_c2_l2 \
     --location 50.83 4.38 --clouds 5 > results.csv
 ```
 
@@ -172,7 +174,7 @@ api = API(username, password)
 
 # Search for Landsat TM scenes
 scenes = api.search(
-    dataset='landsat_tm_c1',
+    dataset='landsat_tm_c2_l1',
     latitude=50.85,
     longitude=-4.35,
     start_date='1995-01-01',

--- a/README.md
+++ b/README.md
@@ -1,30 +1,19 @@
-[![Build](https://img.shields.io/github/workflow/status/yannforget/landsatxplore/Upload%20Python%20Package?label=build&logo=github)](https://github.com/yannforget/landsatxplore/actions/workflows/python-publish.yml)
-[![Tests](https://img.shields.io/github/workflow/status/yannforget/landsatxplore/Run%20tests?label=tests&logo=github)](https://github.com/yannforget/landsatxplore/actions/workflows/run-tests.yml)
-[![codecov](https://codecov.io/gh/yannforget/landsatxplore/branch/master/graph/badge.svg?token=NwVo09Edur)](https://codecov.io/gh/yannforget/landsatxplore)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1291422.svg)](https://zenodo.org/record/4543601)
-
 # Description
 
-![CLI Demo](https://raw.githubusercontent.com/yannforget/landsatxplore/master/demo.gif?s=0.5)
-
-The **landsatxplore** Python package provides an interface to the [EarthExplorer](http://earthexplorer.usgs.gov/) portal to search and download [Landsat Collections](https://landsat.usgs.gov/landsat-collections) scenes through a command-line interface or a Python API.
+This is a working fork of the **landsatxplore** Python package, which provides an interface to the [EarthExplorer](http://earthexplorer.usgs.gov/) portal to search and download [Landsat Collections](https://landsat.usgs.gov/landsat-collections) scenes through a command-line interface or a Python API. With respect to the original (and now unfortunately abandoned) repo, I removed the decomissioned datasets and fixed some of the issues that kept it from working.
+These issues were mostly related to outdated dataset ids, to resolve which "permanently" would require restricting the userbase of this Python module to Earth Explorer users with API access. Rather than doing this, I updated the code as suggested by some users in the issues of the old repo, and I will continue doing so for the foreseeable future if necessary.
 
 The following datasets are supported:
 
 
 | Dataset Name | Dataset ID |
 |-|-|
-| Landsat 5 TM Collection 1 Level 1 | `landsat_tm_c1` |
 | Landsat 5 TM Collection 2 Level 1 | `landsat_tm_c2_l1` |
 | Landsat 5 TM Collection 2 Level 2 | `landsat_tm_c2_l2` |
-| Landsat 7 ETM+ Collection 1 Level 1 | `landsat_etm_c1` |
 | Landsat 7 ETM+ Collection 2 Level 1 | `landsat_etm_c2_l1` |
 | Landsat 7 ETM+ Collection 2 Level 2 | `landsat_etm_c2_l2` |
-| Landsat 8 Collection 1 Level 1 | `landsat_8_c1` |
 | Landsat 8 Collection 2 Level 1 | `landsat_ot_c2_l1` |
 | Landsat 8 Collection 2 Level 2 | `landsat_ot_c2_l2` |
-| Sentinel 2A | `sentinel_2a` |
-
 
 # Quick start
 

--- a/landsatxplore/cli.py
+++ b/landsatxplore/cli.py
@@ -151,8 +151,9 @@ def search(
     "--timeout", "-t", type=click.INT, default=300, help="Download timeout in seconds."
 )
 @click.option("--skip", is_flag=True, default=False)
+@click.option("--overwrite", is_flag=True, default=False)
 @click.argument("scenes", type=click.STRING, nargs=-1)
-def download(username, password, dataset, output, timeout, skip, scenes):
+def download(username, password, dataset, output, timeout, skip, overwrite, scenes):
     """Download one or several scenes."""
     ee = EarthExplorer(username, password)
     output_dir = os.path.abspath(output)
@@ -162,7 +163,12 @@ def download(username, password, dataset, output, timeout, skip, scenes):
         if not ee.logged_in():
             ee = EarthExplorer(username, password)
         fname = ee.download(
-            scene, output_dir, dataset=dataset, timeout=timeout, skip=skip
+            scene,
+            output_dir,
+            dataset=dataset,
+            timeout=timeout,
+            skip=skip,
+            overwrite=overwrite,
         )
         if skip:
             click.echo(fname)

--- a/landsatxplore/earthexplorer.py
+++ b/landsatxplore/earthexplorer.py
@@ -20,7 +20,7 @@ EE_DOWNLOAD_URL = (
 
 # IDs of GeoTIFF data product for each dataset
 DATA_PRODUCTS = {
-    "landsat_tm_c1": "5e83d08fd9932768",
+    #"landsat_tm_c1": "5e83d08fd9932768",
     "landsat_etm_c1": "5e83a507d6aaa3db",
     "landsat_8_c1": "5e83d0b84df8d8c2",
     "landsat_tm_c2_l1": "5e83d0a0f94d7d8d",
@@ -29,21 +29,18 @@ DATA_PRODUCTS = {
     "landsat_tm_c2_l2": "5e83d11933473426",
     "landsat_etm_c2_l2": "5e83d12aada2e3c5",
     "landsat_ot_c2_l2": "5e83d14f30ea90a9",
-    "sentinel_2a": "5e83a42c6eba8084",
+    #"sentinel_2a": "5e83a42c6eba8084",
 }
 
 
 def _get_tokens(body):
     """Get `csrf_token` and `__ncforminfo`."""
     csrf = re.findall(r'name="csrf" value="(.+?)"', body)[0]
-    ncform = re.findall(r'name="__ncforminfo" value="(.+?)"', body)[0]
-
+    
     if not csrf:
         raise EarthExplorerError("EE: login failed (csrf token not found).")
-    if not ncform:
-        raise EarthExplorerError("EE: login failed (ncforminfo not found).")
 
-    return csrf, ncform
+    return csrf
 
 
 class EarthExplorer(object):
@@ -63,12 +60,11 @@ class EarthExplorer(object):
     def login(self, username, password):
         """Login to Earth Explorer."""
         rsp = self.session.get(EE_LOGIN_URL)
-        csrf, ncform = _get_tokens(rsp.text)
+        csrf = _get_tokens(rsp.text)
         payload = {
             "username": username,
             "password": password,
             "csrf": csrf,
-            "__ncforminfo": ncform,
         }
         rsp = self.session.post(EE_LOGIN_URL, data=payload, allow_redirects=True)
 

--- a/landsatxplore/earthexplorer.py
+++ b/landsatxplore/earthexplorer.py
@@ -33,8 +33,8 @@ DATA_PRODUCTS = {
 }
 
 
-def _get_tokens(body):
-    """Get `csrf_token` and `__ncforminfo`."""
+def _get_token(body):
+    """Get `csrf_token`."""
     csrf = re.findall(r'name="csrf" value="(.+?)"', body)[0]
     
     if not csrf:
@@ -60,7 +60,7 @@ class EarthExplorer(object):
     def login(self, username, password):
         """Login to Earth Explorer."""
         rsp = self.session.get(EE_LOGIN_URL)
-        csrf = _get_tokens(rsp.text)
+        csrf = _get_token(rsp.text)
         payload = {
             "username": username,
             "password": password,

--- a/landsatxplore/earthexplorer.py
+++ b/landsatxplore/earthexplorer.py
@@ -20,18 +20,15 @@ EE_DOWNLOAD_URL = (
 
 # IDs of GeoTIFF data product for each dataset
 DATA_PRODUCTS = {
-    #"landsat_tm_c1": "5e83d08fd9932768",
-    "landsat_etm_c1": "5e83a507d6aaa3db",
-    "landsat_8_c1": "5e83d0b84df8d8c2",
-    "landsat_tm_c2_l1": "5e83d0a0f94d7d8d",
-    "landsat_etm_c2_l1": "5e83d0d0d2aaa488",
-    "landsat_ot_c2_l1": "5e81f14ff4f9941c",
-    "landsat_tm_c2_l2": "5e83d11933473426",
-    "landsat_etm_c2_l2": "5e83d12aada2e3c5",
-    "landsat_ot_c2_l2": "5e83d14f30ea90a9",
-    #"sentinel_2a": "5e83a42c6eba8084",
+    # Level 1 datasets
+    "landsat_tm_c2_l1": ["5e81f14f92acf9ef", "5e83d0a0f94d7d8d", "63231219fdd8c4e5"],
+    "landsat_etm_c2_l1":[ "5e83d0d0d2aaa488", "5e83d0d08fec8a66"],
+    "landsat_ot_c2_l1": ["5e81f14ff4f9941c", "5e81f14f92acf9ef"],
+    # Level 2 datasets
+    "landsat_tm_c2_l2": ["5e83d11933473426", "5e83d11933473426", "632312ba6c0988ef"],
+    "landsat_etm_c2_l2": ["5e83d12aada2e3c5", "5e83d12aed0efa58", "632311068b0935a8"],
+    "landsat_ot_c2_l2": ["5e83d14f30ea90a9", "5e83d14fec7cae84", "632210d4770592cf"]
 }
-
 
 def _get_token(body):
     """Get `csrf_token`."""
@@ -41,7 +38,6 @@ def _get_token(body):
         raise EarthExplorerError("EE: login failed (csrf token not found).")
 
     return csrf
-
 
 class EarthExplorer(object):
     """Access Earth Explorer portal."""
@@ -74,7 +70,7 @@ class EarthExplorer(object):
     def logout(self):
         """Log out from Earth Explorer."""
         self.session.get(EE_LOGOUT_URL)
-
+    
     def _download(
         self, url, output_dir, timeout, chunk_size=1024, skip=False, overwrite=False
     ):
@@ -189,10 +185,22 @@ class EarthExplorer(object):
             entity_id = self.api.get_entity_id(identifier, dataset)
         else:
             entity_id = identifier
-        url = EE_DOWNLOAD_URL.format(
-            data_product_id=DATA_PRODUCTS[dataset], entity_id=entity_id
-        )
-        filename = self._download(
-            url, output_dir, timeout=timeout, skip=skip, overwrite=overwrite
-        )
+        # Cycle through the available dataset ids until one works
+        dataset_id_list = DATA_PRODUCTS[dataset]
+        id_num = len(dataset_id_list)
+        for id_count, dataset_id in enumerate(dataset_id_list):
+            try:
+                url = EE_DOWNLOAD_URL.format(
+                    data_product_id=dataset_id, entity_id=entity_id
+                )
+                filename = self._download(
+                    url, output_dir, timeout=timeout, skip=skip, overwrite=overwrite
+                )
+            except EarthExplorerError:
+                if id_count+1 < id_num:
+                    print('Download failed with dataset id {:d} of {:d}. Re-trying with the next one.'.format(id_count+1, id_num))
+                    pass
+                else:
+                    print('None of the archived ids succeeded! Update necessary!')
+                    raise EarthExplorerError()
         return filename

--- a/landsatxplore/util.py
+++ b/landsatxplore/util.py
@@ -87,16 +87,16 @@ def parse_scene_id(scene_id):
     }
 
 
-def landsat_dataset(satellite, collection="c1", level="l1"):
+def landsat_dataset(satellite, collection="c2", level="l1"):
     """Get landsat dataset name."""
     if satellite == 5:
         sensor = "tm"
         collection = "c2"
     elif satellite == 7:
         sensor = "etm"
-    elif satellite == 8 and collection == "c1":
-        sensor = "8"
-    elif satellite == 8 and collection == "c2":
+    elif satellite in (8, 9) and collection == "c1":
+        raise ValueError('Collection 1 was decommissioned!')
+    elif satellite in [8, 9] and collection == "c2":
         sensor = "ot"
     else:
         raise LandsatxploreError("Failed to guess dataset from identifier.")

--- a/landsatxplore/util.py
+++ b/landsatxplore/util.py
@@ -91,6 +91,7 @@ def landsat_dataset(satellite, collection="c1", level="l1"):
     """Get landsat dataset name."""
     if satellite == 5:
         sensor = "tm"
+        collection = "c2"
     elif satellite == 7:
         sensor = "etm"
     elif satellite == 8 and collection == "c1":


### PR DESCRIPTION
Using old issues, PRs and doing new research I:

- Removed decommissioned datasets
- Explicitly added Landsat 9
- Pulled the implementation of partial downloads
- Fixed download ids

Both the command line and the Python bindings work for all the datasets listed in the README. I also tested the partial download feature implemented by @alexVyth, which works like a charm and is very handy. The most important updates are detailed in this commit https://github.com/yannforget/landsatxplore/commit/f31685c6b7ac6ee3aa207c5b486230d27fe6384f

Some references to decommissioned collection 1 products may still be present in the code (and ideally should be cleaned up), but should not hinder the functionality of the module.