### PR TITLE
Update earthexplorer.py

### DIFF
--- a/landsatxplore/earthexplorer.py
+++ b/landsatxplore/earthexplorer.py
@@ -188,6 +188,7 @@ class EarthExplorer(object):
         # Cycle through the available dataset ids until one works
         dataset_id_list = DATA_PRODUCTS[dataset]
         id_num = len(dataset_id_list)
+        filename = ''
         for id_count, dataset_id in enumerate(dataset_id_list):
             try:
                 url = EE_DOWNLOAD_URL.format(
@@ -196,12 +197,13 @@ class EarthExplorer(object):
                 filename = self._download(
                     url, output_dir, timeout=timeout, skip=skip, overwrite=overwrite
                 )
-                break
+                print('Download success with dataset id {:d} of {:d}.'.format(id_count + 1, id_num))
             except EarthExplorerError:
-                if id_count+1 < id_num:
-                    print('Download failed with dataset id {:d} of {:d}. Re-trying with the next one.'.format(id_count+1, id_num))
-                    pass
-                else:
-                    print('None of the archived ids succeeded! Update necessary!')
-                    raise EarthExplorerError()
+                print('Download failed with dataset id {:d} of {:d}. Re-trying with the next one.'.format(id_count+1,id_num))
+                #if id_count+1 < id_num:
+                #    print('Download failed with dataset id {:d} of {:d}. Re-trying with the next one.'.format(id_count+1, id_num))
+                #    pass
+                #else:
+                #    print('None of the archived ids succeeded! Update necessary!')
+                #    raise EarthExplorerError()
         return filename


### PR DESCRIPTION
Due to DATA_ PRODUCTS is a list, and when in a for loop, as long as there is one successful download, it can be assumed that it does not necessarily have to be downloaded successfully all three times. Therefore, throwing exceptions in the for loop is unscientific. I downloaded the data using this method successfully in the second round, but failed in the third round. The data can be downloaded locally, but there is a prompt of None of the archived ids succeeded! Update necessary Therefore, it is recommended to modify according to the above method. The caller can also determine whether the data download was successful by checking if the file name is empty.